### PR TITLE
Add a check for window.id being null

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'react/jsx-filename-extension': 'off',
     'no-nested-ternary': 'off',
     'no-param-reassign': 'off',
-    'react/jsx-one-expression-per-line': 'off'
+    'react/jsx-one-expression-per-line': 'off',
+    'max-len': 'off'
   }
 };

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import Title from './components/Title.jsx';
 import HouseInfo from './components/HouseInfo.jsx';
 
-const id = window.id === undefined ? faker.random.number({ min: 1, max: 100 }) : window.id;
+const id = (window.id === undefined || window.id === null) ? faker.random.number({ min: 1, max: 100 }) : window.id;
 
 const Wrapper = styled.section`
       @import url('https://fonts.googleapis.com/css?family=Montserrat:300,400,600,700');


### PR DESCRIPTION
Service was not rendering properly if window.id was set to null. Now renders properly if window.id is undefined or set to null.